### PR TITLE
WIP: Ignore prefix files

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   skip: True  # [osx or win]
-  number: 2
+  number: 3
   features:
     - blas_{{ variant }}
   ignore_prefix_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,9 @@ build:
   number: 2
   features:
     - blas_{{ variant }}
+  ignore_prefix_files:
+    - bin/julia
+    - bin/julia-debug
 
 requirements:
   build:


### PR DESCRIPTION
Try ignoring the prefix (if detected) in the julia executables. This seems like a potential cause of the [warnings]( https://github.com/conda-forge/julia-feedstock/pull/7#issuecomment-329283460 ) we have been seeing.