### PR TITLE
Fix link/unlink step

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   skip: True  # [osx or win]
-  number: 4
+  number: 5
   features:
     - blas_{{ variant }}
 

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,1 +1,1 @@
-"${PREFIX}/bin/julia" -e 'Pkg.init()'
+"${PREFIX}/bin/julia" -e 'Pkg.init()' >> "${PREFIX}/.messages.txt" 2>&1

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,1 +1,1 @@
-julia -e 'Pkg.init()'
+"${PREFIX}/bin/julia" -e 'Pkg.init()'

--- a/recipe/pre-unlink.sh
+++ b/recipe/pre-unlink.sh
@@ -1,1 +1,1 @@
-"${PREFIX}/bin/julia" -e 'rm(ENV["JULIA_PKGDIR"], recursive=true)'
+"${PREFIX}/bin/julia" -e 'rm(ENV["JULIA_PKGDIR"], recursive=true)' >> "${PREFIX}/.messages.txt" 2>&1

--- a/recipe/pre-unlink.sh
+++ b/recipe/pre-unlink.sh
@@ -1,1 +1,1 @@
-julia -e 'rm(ENV["JULIA_PKGDIR"], recursive=true)'
+"${PREFIX}/bin/julia" -e 'rm(ENV["JULIA_PKGDIR"], recursive=true)'

--- a/recipe/pre-unlink.sh
+++ b/recipe/pre-unlink.sh
@@ -1,0 +1,1 @@
+julia -e 'rm(ENV["JULIA_PKGDIR"], recursive=true)'


### PR DESCRIPTION
Realized there were some oversights in our original linking script from PR ( https://github.com/conda-forge/julia-feedstock/pull/11 ). Have tried to address them in this PR. Listed the changes below. Also bumped the build number to get a fresh build with these changes.

* Add an unlink script to cleanup Julia packages on uninstall.
* Specify the exact path to `julia` when calling it.
* Redirect link/unlink stdout/stderr to `${PREFIX}/.messages.txt`.