### PR TITLE
Use patchelf on Linux only

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ build:
 requirements:
   build:
     - toolchain
-    - patchelf
+    - patchelf  # [linux]
     - cmake
     - zlib 1.2.8
     - python 2.7.*


### PR DESCRIPTION
This doesn't matter much while we are only building for Linux. However once we start building for macOS or even Windows, we will want to ensure that `patchelf` is only pulled on Linux. Hence we add this selector. Though this is really a no-op as far as the Linux build is concerned.