### PR TITLE
Skip doc build

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,6 +5,12 @@ export LD_LIBRARY_PATH=${PREFIX}/lib
 export LIBRARY_PATH=${PREFIX}/lib
 export CMAKE_PREFIX_PATH=${PREFIX}
 
+# Hack to suppress building docs
+cat > doc/Makefile << EOF
+html :	
+	mkdir -p _build/html
+EOF
+
 make -j 4 prefix=${PREFIX} MARCH=core2 sysconfigdir=${PREFIX}/etc NO_GIT=1 \
  LIBBLAS=-lopenblas LIBBLASNAME=libopenblas${SHLIB_EXT} LIBLAPACK=-lopenblas LIBLAPACKNAME=libopenblas${SHLIB_EXT} \
  USE_SYSTEM_LIBGIT2=1 USE_LLVM_SHLIB=0 USE_SYSTEM_CURL=1 USE_SYSTEM_OPENLIBM=1 USE_SYSTEM_MPFR=1 \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   skip: True  # [osx or win]
-  number: 5
+  number: 6
   features:
     - blas_{{ variant }}
 


### PR DESCRIPTION
Fixes https://github.com/conda-forge/julia-feedstock/issues/27

Overwrite `doc/Makefile` so as to avoid building the docs. Make sure to create the intended output directory though so that the install step can still find it (even though it is empty).