### PR TITLE
Respect isolation of conda environments and their dependencies

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -52,3 +52,24 @@ make -j 4 prefix=${PREFIX} MARCH=core2 sysconfigdir=${PREFIX}/etc NO_GIT=1 \
 
 # Configure juliarc to use conda environment
 cat "${RECIPE_DIR}/juliarc.jl" >> "${PREFIX}/etc/julia/juliarc.jl"
+
+# If julia is running in a conda environment, install packages in env folder
+mkdir -p "${PREFIX}/etc/julia/packages/"
+
+cat <<EOF > "${PREFIX}/etc/conda/activate.d/julia-activate.sh"
+#!/usr/bin/env sh
+export LAST_JULIA_DEPOT_PATH=\$JULIA_DEPOT_PATH
+export LAST_JULIA_LOAD_PATH=\$JULIA_LOAD_PATH
+export JULIA_DEPOT_PATH='${PREFIX}/etc/julia/packages/'
+export JULIA_LOAD_PATH='@:@stdlib'"
+EOF
+
+cat <<EOF > "${PREFIX}/etc/conda/deactivate.d/julia-deactivate.sh"
+#!/usr/bin/env sh
+export JULIA_DEPOT_PATH=\$LAST_JULIA_DEPOT_PATH"
+export JULIA_LOAD_PATH=\$LAST_JULIA_LOAD_PATH"
+export LAST_JULIA_DEPOT_PATH=
+export LAST_JULIA_LOAD_PATH=
+EOF
+
+chmod +x "${PREFIX}/activate.d/*" "${PREFIX}/deactivate.d/*"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   skip: True  # [win]
-  number: 4
+  number: 5
   features:
 
 requirements:


### PR DESCRIPTION
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Currently Julia installs all packages into the users home folder. This breaks when the users home folder doesn't exist or the conda environment is shared. It also violates the isolation of conda environments. All environment dependencies should be installed into the environment folder.

This PR adds a activation script that modifies JULIA_DEPOT_PATH and JULIA_LOAD_PATH to exclude the home folder in place of a path in `${PREFIX}/etc/julia/packages/`
