### PR TITLE
Pin suitesparse to 5.4.0 in run for Julia 1.6.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,7 @@ requirements:
     - mpfr
     - openlibm
     - arpack
-    - suitesparse
+    - suitesparse =5.4.0
     - pcre2
     - curl
     - libgit2  # [not osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 0
+  number: 1
   features:
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Addresses #118 

<!--
Please add any other relevant info below:
-->

We previously only pinned suitesparse to 5.4.0 for host. This adds the suitesparse pin to 5.4.0 for run.
